### PR TITLE
Resolves user validation on signup

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -46,7 +46,6 @@ const makeErrorHandler = (res, next) =>
 
 const signup = (req, res, next) => {
   const credentials = req.body.credentials
-  console.log(credentials)
   const user = { email: credentials.email, password: credentials.password, password_confirmation: credentials.password_confirmation }
   getToken()
     .then(token => {
@@ -54,13 +53,13 @@ const signup = (req, res, next) => {
     })
     .then(() => {
       if (user.password !== user.password_confirmation) {
-        throw res.status(400)
+        return Promise.reject(new HttpError(400))
       }
-      new User(user).save()
     })
+    .then(() => new User(user).save())
     .then(user =>
       res.status(201).json({ user }))
-      .catch(makeErrorHandler(res, next))
+    .catch(makeErrorHandler(res, next))
 }
 
 const signin = (req, res, next) => {


### PR DESCRIPTION
Users were getting inaccurate messages when creating accounts that
already existed. This should resolve that.

PASSED = working as intended
FAILED = still not working

Testing:
  Create account that exists with new matching pass/pass_conf - PASSED
  Create account that exists with non-matching pass/pass_conf - PASSED
  Create new account that has non-matching pass/pass_conf     - PASSED
  Create new account with matching pass/pass_conf             - PASSED

Should implement client side validation for passwords now. Currently
both, failing to use the correct password/pass combination or trying to
create an account that already exists, return 400 error